### PR TITLE
Fixes conflict between different doobie versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,8 @@ lazy val doobie = (project in file("."))
   .settings(
     organization := "org.scala-exercises",
     name         := "exercises-doobie",
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.8",
+    parallelExecution in Test := false,
     version := "0.2.2-SNAPSHOT",
     resolvers ++= Seq(
       Resolver.sonatypeRepo("snapshots"),
@@ -16,8 +17,8 @@ lazy val doobie = (project in file("."))
       "org.scala-exercises" %% "definitions" % version.value,
       "org.scalacheck" %% "scalacheck" % "1.12.5",
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.12" % "0.3.1",
-      "org.tpolecat" %% "doobie-core" % "0.3.0",
-      "org.tpolecat" %% "doobie-contrib-h2" % "0.3.0",
+      "org.tpolecat" %% "doobie-core" % "0.2.3",
+      "org.tpolecat" %% "doobie-contrib-h2" % "0.2.3",
       compilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1")
     )
   )

--- a/src/main/scala/doobie/ConnectingToDatabaseSection.scala
+++ b/src/main/scala/doobie/ConnectingToDatabaseSection.scala
@@ -1,13 +1,12 @@
 package doobie
 
-import org.scalatest._
+import doobie.DoobieUtils._
 import doobie.imports._
 import org.scalaexercises.definitions.Section
+import org.scalatest._
 
+import scalaz.Scalaz._
 import scalaz._
-import Scalaz._
-import scala.util.Random
-import scalaz.concurrent.Task
 
 /** ==Introduction==
   * doobie is a monadic API that provides a number of data types that all work the same way
@@ -59,13 +58,6 @@ import scalaz.concurrent.Task
   * @param name connecting_to_database
   */
 object ConnectingToDatabaseSection extends FlatSpec with Matchers with Section {
-
-  val xa = DriverManagerTransactor[Task](
-    driver = "org.h2.Driver",
-    url = s"jdbc:h2:mem:doobie-exercises-${Random.nextFloat()};DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
-    user = "sa",
-    pass = ""
-  )
 
   /**
     * Right, so let’s do this.

--- a/src/main/scala/doobie/DoobieUtils.scala
+++ b/src/main/scala/doobie/DoobieUtils.scala
@@ -2,7 +2,7 @@ package doobie
 
 import java.util.UUID
 
-import doobie.Model.Country
+import doobie.Model._
 import doobie.imports._
 
 import scalaz.concurrent.Task
@@ -17,7 +17,7 @@ object DoobieUtils {
     pass = ""
   )
 
-  val createCountryTable: ConnectionIO[Int] = {
+  val createCountryTable: ConnectionIO[Int] =
     sql"""
         CREATE TABLE IF NOT EXISTS country (
         code        VARCHAR(64),
@@ -26,10 +26,16 @@ object DoobieUtils {
         gnp         DECIMAL(10,2)
         )
      """.update.run
-  }
 
   val dropCountryTable: ConnectionIO[Int] = sql"""DROP TABLE IF EXISTS country""".update.run
 
   def insertCountries(countries: List[Country]): ConnectionIO[Int] =
-    Update[Country]("insert into country (code, name, population, gnp) values (?,?,?,?)").updateMany(countries)
+    Update[Country](s"insert into country (code, name, population, gnp) values (?,?,?,?)").updateMany(countries)
+
+  val initializeData = for {
+    _ <- createCountryTable
+    _ <- insertCountries(countries)
+  } yield Unit
+
+  val cleanupData = dropCountryTable
 }

--- a/src/main/scala/doobie/Model.scala
+++ b/src/main/scala/doobie/Model.scala
@@ -2,13 +2,13 @@ package doobie
 
 object Model {
 
-  case class Country(code: String, name: String, population: Long, gnp: Double)
+  case class Country(code: String, name: String, population: Long, gnp: Option[Double])
 
   val countries = List(
-    Country("DEU", "Germany", 82164700, 2133367.00),
-    Country("ESP", "Spain", 39441700, 553223.00),
-    Country("FRA", "France", 59225700, 1424285.00),
-    Country("GBR", "United Kingdom", 59623400, 1378330.00),
-    Country("USA", "United States of America", 278357000, 8510700.00)
+    Country("DEU", "Germany", 82164700, Option(2133367.00)),
+    Country("ESP", "Spain", 39441700, Option(553223.00)),
+    Country("FRA", "France", 59225700, Option(1424285.00)),
+    Country("GBR", "United Kingdom", 59623400, Option(1378330.00)),
+    Country("USA", "United States of America", 278357000, Option(8510700.00))
   )
 }

--- a/src/main/scala/doobie/SelectingDataSection.scala
+++ b/src/main/scala/doobie/SelectingDataSection.scala
@@ -1,7 +1,6 @@
 package doobie
 
 import doobie.DoobieUtils._
-import doobie.Model._
 import doobie.imports._
 import org.scalaexercises.definitions.Section
 import org.scalatest.{FlatSpec, Matchers}
@@ -58,13 +57,6 @@ import org.scalatest.{FlatSpec, Matchers}
   * @param name selecting_data
   */
 object SelectingDataSection extends FlatSpec with Matchers with Section {
-
-  val initializeData = for {
-    _ <- createCountryTable
-    _ <- insertCountries(countries)
-  } yield Unit
-
-  val cleanupData = dropCountryTable
 
   /**
     * == Getting info about the countries ==

--- a/src/test/scala/doobie/SelectingDataSectionSpec.scala
+++ b/src/test/scala/doobie/SelectingDataSectionSpec.scala
@@ -1,6 +1,5 @@
-package exercises.doobie
+package doobie
 
-import doobie._
 import org.scalacheck.Shapeless._
 import org.scalaexercises.Test
 import org.scalatest.Spec


### PR DESCRIPTION
This pull request fixes a bug related to the use of a different version of `doobie` library than the used one in `scala-exercises`. 

It also refactors some duplicated code.

@dialelo Could you take a look please? Thanks