### PR TITLE
replace inDb with custom transactor

### DIFF
--- a/src/main/scala/doobie/DoobieUtils.scala
+++ b/src/main/scala/doobie/DoobieUtils.scala
@@ -6,6 +6,8 @@ import doobie.Model._
 import doobie.imports._
 import doobie.free.{ drivermanager => FD }
 
+import java.sql.Connection
+
 import scalaz.concurrent.Task
 import scalaz._, Scalaz._
 
@@ -14,12 +16,12 @@ object DoobieUtils {
   // Transactor for single-use in-memory databases pre-populated with test data.
   val xa = new Transactor[Task] {
 
-    val driver =  "org.h2.Driver"
-    def url    = s"jdbc:h2:mem:"
-    val user   =  "sa"
-    val pass   =  ""
+    val driver = "org.h2.Driver"
+    def url    = "jdbc:h2:mem:"
+    val user   = "sa"
+    val pass   = ""
 
-    val connect =
+    val connect: Task[Connection] =
       Task.delay(Class.forName(driver)) *> FD.getConnection(url, user, pass).trans[Task]
 
     val createCountryTable: ConnectionIO[Int] =

--- a/src/main/scala/doobie/SelectingDataSection.scala
+++ b/src/main/scala/doobie/SelectingDataSection.scala
@@ -6,7 +6,7 @@ import org.scalaexercises.definitions.Section
 import org.scalatest.{FlatSpec, Matchers}
 
 /**
-  * We are gonna construct some programs that retrieve data from the database and stream it back,
+  * We are going to construct some programs that retrieve data from the database and stream it back,
   * mapping to Scala types on the way.
   *
   * We will be playing with the country table that has the following structure:
@@ -54,27 +54,6 @@ import org.scalatest.{FlatSpec, Matchers}
   *  - See the Scaladoc for [[http://tpolecat.github.io/doc/doobie/0.3.0/api/index.html#doobie.util.query$$Query0 `Query0`]]
   * for more information on these and other methods.
   *
-  * == Note ==
-  *
-  * To run the exercises, we need to create a table in memory and populate it before each exercise
-  * and clean up the data once the exercise has been run.
-  *
-  * To do that, we have defined a method called `inDb` that:
-  *  - receives a doobie code block that performs a query to the database
-  *  - executes the data initialization (before running the provided code block) and performs a
-  * cleanup task at the end of the execution
-  *  - returns a ConnectionIO that contains the result of the query
-  *
-  * {{{
-  * def inDb[A](thunk: => ConnectionIO[A]) = for {
-  *   _ <- initializeData
-  *   result <- thunk
-  *   _ <- cleanupData
-  * } yield result
-  * }}}
-  *
-  * So, whenever you find an `inDb` wrapper, it's just performing the tasks described above.
-  *
   * @param name selecting_data
   */
 object SelectingDataSection extends FlatSpec with Matchers with Section {
@@ -86,9 +65,12 @@ object SelectingDataSection extends FlatSpec with Matchers with Section {
     */
   def selectUniqueCountryName(res0: String) = {
 
-    val countryName = inDb {
-      sql"select name from country where code = 'ESP'".query[String].unique
-    }.transact(xa).run
+    val countryName =
+      sql"select name from country where code = 'ESP'"
+        .query[String]
+        .unique
+        .transact(xa)
+        .run
 
     countryName should be(res0)
   }
@@ -98,9 +80,12 @@ object SelectingDataSection extends FlatSpec with Matchers with Section {
     */
   def selectOptionalCountryName(res0: Option[String]) = {
 
-    val maybeCountryName = inDb {
-      sql"select name from country where code = 'ITA'".query[String].option
-    }.transact(xa).run
+    val maybeCountryName =
+      sql"select name from country where code = 'ITA'"
+        .query[String]
+        .option
+        .transact(xa)
+        .run
 
     maybeCountryName should be(res0)
   }
@@ -111,9 +96,12 @@ object SelectingDataSection extends FlatSpec with Matchers with Section {
     */
   def selectCountryNameList(res0: String) = {
 
-    val countryNames = inDb {
-      sql"select name from country order by name".query[String].list
-    }.transact(xa).run
+    val countryNames =
+      sql"select name from country order by name"
+        .query[String]
+        .list
+        .transact(xa)
+        .run
 
     countryNames.head should be(res0)
   }
@@ -130,9 +118,14 @@ object SelectingDataSection extends FlatSpec with Matchers with Section {
     */
   def selectCountryNameListByUsingProcess(res0: Int) = {
 
-    val countryNames = inDb {
-      sql"select name from country order by name".query[String].process.take(3).list
-    }.transact(xa).run
+    val countryNames =
+      sql"select name from country order by name"
+        .query[String]
+        .process
+        .take(3)
+        .list
+        .transact(xa)
+        .run
 
     countryNames.size should be(res0)
   }


### PR DESCRIPTION
The `inDb` method seemed like an implementation leakage so I removed it in favor of a custom `Transactor` that automatically does the setup. So to the user it appears that the data is already there. I also changed the connection URL to `jdbc:h2:mem:` which gives you a private single-use database that is discarded when the connection is closed, so there is no need to worry about cleanup.

I also reformatted the examples a bit, which I'm happy to undo if you don't like it that way.