### PR TITLE
Adds a new exercise with shapeless record

### DIFF
--- a/src/main/scala/doobie/MultiColumnQueriesSection.scala
+++ b/src/main/scala/doobie/MultiColumnQueriesSection.scala
@@ -63,7 +63,7 @@ object MultiColumnQueriesSection extends FlatSpec with Matchers with Section {
 
     hlist.head should be(res0)
   }
-/*
+
   /**
     * And with a shapeless record:
     */
@@ -80,7 +80,7 @@ object MultiColumnQueriesSection extends FlatSpec with Matchers with Section {
 
     record('pop) should be(res0)
   }
-*/
+
   /**
     * And again, mapping rows to a case class.
     *

--- a/src/test/scala/doobie/MultiColumnQueriesSectionSpec.scala
+++ b/src/test/scala/doobie/MultiColumnQueriesSectionSpec.scala
@@ -27,7 +27,7 @@ class MultiColumnQueriesSectionSpec extends Spec with Checkers {
       )
     )
   }
-/*
+
   def `select multiple columns using Record` = {
     check(
       Test.testSuccess(
@@ -36,7 +36,7 @@ class MultiColumnQueriesSectionSpec extends Spec with Checkers {
       )
     )
   }
-*/
+
   def `select multiple columns using case class` = {
     check(
       Test.testSuccess(


### PR DESCRIPTION
This pull request adds a new exercise about shapeless Record that was disabled previously because of an error of the scala-exercises compiler.

It also increases the version number to `0.2.3`

It closes scala-exercises/exercises-doobie#1

@dialelo Could you review at your convenience? Thanks!