### PR TITLE
Adding some padding to UpdatesSection.scala

### DIFF
--- a/src/main/scala/doobie/UpdatesSection.scala
+++ b/src/main/scala/doobie/UpdatesSection.scala
@@ -23,18 +23,18 @@ import scalaz._, Scalaz._
   *
   * {{{
   * val drop: Update0 =
-  * sql"""
-  * DROP TABLE IF EXISTS person
-  * """.update
+  *   sql"""
+  *   DROP TABLE IF EXISTS person
+  *   """.update
   *
   * val create: Update0 =
-  * sql"""
-  * CREATE TABLE person (
-  * id   SERIAL,
-  * name VARCHAR NOT NULL UNIQUE,
-  * age  SMALLINT
-  * )
-  * """.update
+  *   sql"""
+  *   CREATE TABLE person (
+  *   id   SERIAL,
+  *   name VARCHAR NOT NULL UNIQUE,
+  *   age  SMALLINT
+  *   )
+  *   """.update
   * }}}
   *
   * We can compose these and run them together.


### PR DESCRIPTION
The "Data Definition" section in "UpdatesSection.scala" seem to be cutting off some of the drop and create statements.  Hoping this padding corrects the issue.


![cuttoff issue](https://cloud.githubusercontent.com/assets/1111592/21083726/5eaa905c-bfbc-11e6-9276-587ed550f089.png)
