### PR TITLE
Integrates sbt-org-policies plugin

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,23 @@
+style = defaultWithAlign
+maxColumn = 100
+
+continuationIndent.callSite = 2
+
+newlines {
+  sometimesBeforeColonInMethodReturnType = false
+}
+
+align {
+  arrowEnumeratorGenerator = false
+  ifWhileOpenParen = false
+  openParenCallSite = false
+  openParenDefnSite = false
+}
+
+docstrings = JavaDoc
+
+rewrite {
+  rules = [SortImports, RedundantBraces]
+  redundantBraces.maxLines = 1
+}
+        

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,3 @@ after_success:
 - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
      sbt compile publishSigned;
   fi
-- if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then
-     echo "Not in master branch, skipping deploy and release";
-  fi

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-#Scala Exercises - Doobie library
-
+# Scala Exercises - Doobie library
 ------------------------
 
 This repository hosts a content library for the [Scala Exercises](https://www.scala-exercises.org/) platform, including interactive exercises related to the [Doobie](https://github.com/tpolecat/doobie) functional JDBC layer.
 
-## About Scala exercises
+## About Scala exercises
 
 "Scala Exercises" brings exercises for the Stdlib, Cats, Shapeless and many other great libraries for Scala to your browser. Offering hundreds of solvable exercises organized into several categories covering the basics of the Scala language and it's most important libraries.
 
@@ -15,7 +14,7 @@ Scala Exercises is available at [scala-exercises.org](https://scala-exercises.or
 Contributions welcome! Please join our [Gitter channel](https://gitter.im/scala-exercises/scala-exercises)
 to get involved, or visit our [GitHub site](https://github.com/scala-exercises).
 
-##License
+## License
 
 Copyright (C) 2015-2016 47 Degrees, LLC.
 Reactive, scalable software solutions.

--- a/build.sbt
+++ b/build.sbt
@@ -1,52 +1,24 @@
+val scalaExerciesV = "0.4.0-SNAPSHOT"
+
+def dep(artifactId: String) = "org.scala-exercises" %% artifactId % scalaExerciesV
+
 lazy val doobie = (project in file("."))
-  .settings(publishSettings:_*)
   .enablePlugins(ExerciseCompilerPlugin)
   .settings(
-    organization := "org.scala-exercises",
     name         := "exercises-doobie",
-    scalaVersion := "2.11.8",
-    parallelExecution in Test := false,
-    version := "0.3.0-SNAPSHOT",
-    resolvers ++= Seq(
-      Resolver.sonatypeRepo("snapshots"),
-      Resolver.sonatypeRepo("releases")
-    ),
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "2.2.4",
-      "org.scala-exercises" %% "exercise-compiler" % version.value,
-      "org.scala-exercises" %% "definitions" % version.value,
-      "org.scalacheck" %% "scalacheck" % "1.12.5",
-      "com.github.alexarchambault" %% "scalacheck-shapeless_1.12" % "0.3.1",
-      "org.tpolecat" %% "doobie-core" % "0.3.0",
-      "org.tpolecat" %% "doobie-contrib-h2" % "0.3.0",
-      compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.0")
+      dep("exercise-compiler"),
+      dep("definitions"),
+      %%("doobie-core"),
+      %%("doobie-h2"),
+      %%("scalatest"),
+      %%("scalacheck"),
+      %%("scheckShapeless")
     )
   )
 
 // Distribution
 
-lazy val gpgFolder = sys.env.getOrElse("PGP_FOLDER", ".")
-
-lazy val publishSettings = Seq(
-  organizationName := "Scala Exercises",
-  organizationHomepage := Some(new URL("https://scala-exercises.org")),
-  startYear := Some(2016),
-  description := "Scala Exercises: The path to enlightenment",
-  homepage := Some(url("https://scala-exercises.org")),
-  pgpPassphrase := Some(sys.env.getOrElse("PGP_PASSPHRASE", "").toCharArray),
-  pgpPublicRing := file(s"$gpgFolder/pubring.gpg"),
-  pgpSecretRing := file(s"$gpgFolder/secring.gpg"),
-  credentials += Credentials("Sonatype Nexus Repository Manager",  "oss.sonatype.org",  sys.env.getOrElse("PUBLISH_USERNAME", ""),  sys.env.getOrElse("PUBLISH_PASSWORD", "")),
-  scmInfo := Some(ScmInfo(url("https://github.com/scala-exercises/exercises-doobie"), "https://github.com/scala-exercises/exercises-doobie.git")),
-  licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
-  publishMavenStyle := true,
-  publishArtifact in Test := false,
-  pomIncludeRepository := Function.const(false),
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot.value)
-      Some("Snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("Releases" at nexus + "service/local/staging/deploy/maven2")
-  }
-)
+pgpPassphrase := Some(getEnvVar("PGP_PASSPHRASE").getOrElse("").toCharArray)
+pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
+pgpSecretRing := file(s"$gpgFolder/secring.gpg")

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,0 +1,47 @@
+import de.heikoseeberger.sbtheader.HeaderPattern
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+import sbtorgpolicies._
+import sbtorgpolicies.model._
+import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
+
+object ProjectPlugin extends AutoPlugin {
+
+  override def trigger: PluginTrigger = allRequirements
+
+  override def requires: Plugins = plugins.JvmPlugin && OrgPoliciesPlugin
+
+  override def projectSettings: Seq[Def.Setting[_]] =
+    Seq(
+      description := "Scala Exercises: The path to enlightenment",
+      startYear := Option(2016),
+      orgGithubSetting := GitHubSettings(
+        organization = "scala-exercises",
+        project = name.value,
+        organizationName = "Scala Exercises",
+        groupId = "org.scala-exercises",
+        organizationHomePage = url("https://www.scala-exercises.org"),
+        organizationEmail = "hello@47deg.com"
+      ),
+      orgLicenseSetting := ApacheLicense,
+      scalaVersion := "2.11.8",
+      scalaOrganization := "org.scala-lang",
+      crossScalaVersions := Seq("2.11.8"),
+      resolvers ++= Seq(
+        Resolver.mavenLocal,
+        Resolver.sonatypeRepo("snapshots"),
+        Resolver.sonatypeRepo("releases")
+      ),
+      scalacOptions := sbtorgpolicies.model.scalacCommonOptions,
+      headers := Map(
+        "scala" -> (HeaderPattern.cStyleBlockComment,
+          s"""|/*
+              | * scala-exercises - ${name.value}
+              | * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+              | */
+              |
+            |""".stripMargin)
+      )
+    )
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.12
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,5 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.3.0-SNAPSHOT", "0.13", "2.10")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.4.0-SNAPSHOT", "0.13", "2.10")
+addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.3.2")

--- a/src/main/scala/doobie/ConnectingToDatabaseSection.scala
+++ b/src/main/scala/doobie/ConnectingToDatabaseSection.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import doobie.DoobieUtils.CountryTable._
@@ -9,76 +14,76 @@ import scalaz.Scalaz._
 import scalaz._
 
 /** ==Introduction==
-  * doobie is a monadic API that provides a number of data types that all work the same way
-  * but describe computations in different contexts.
-  *
-  * In the doobie high level API the most common types we will deal with have the form
-  * ConnectionIO[A], specifying computations that take place in a context where a
-  * java.sql.Connection is available, ultimately producing a value of type A.
-  *
-  * doobie programs are values. You can compose small programs to build larger programs. Once you
-  * have constructed a program you wish to run, you interpret it into an effectful target monad of
-  * your choice (Task or IO for example) and drop it into your main application wherever you like.
-  *
-  * ==First programs==
-  *
-  * {{{
-  * import doobie.imports._
-  * import scalaz._, Scalaz._
-  * import scalaz.concurrent.Task
-  * }}}
-  *
-  * So let’s start with a ConnectionIO program that simply returns a constant.
-  *
-  * {{{
-  * val program = 42.point[ConnectionIO]
-  * program: ConnectionIO[Int] = Return(42)
-  * }}}
-  *
-  * This is a perfectly respectable doobie program, but we can’t run it as-is; we need a Connection
-  * first. There are several ways to do this, but here let’s use a Transactor.
-  *
-  * {{{
-  * val xa = DriverManagerTransactor[Task](
-  * driver = "org.postgresql.Driver",
-  * url = "jdbc:postgresql:world",
-  * user = "postgres",
-  * pass = ""
-  * )
-  * }}}
-  *
-  * A Transactor is simply a structure that knows how to connect to a database, hand out
-  * connections, and clean them up; and with this knowledge it can transform ConnectionIO ~> Task,
-  * which gives us something we can run. Specifically it gives us a Task that, when run, will
-  * connect to the database and run our program in a single transaction.
-  *
-  * The DriverManagerTransactor simply delegates to the java.sql.DriverManager to allocate
-  * connections, which is fine for development but inefficient for production use.
-  *
-  * @param name connecting_to_database
-  */
+ * doobie is a monadic API that provides a number of data types that all work the same way
+ * but describe computations in different contexts.
+ *
+ * In the doobie high level API the most common types we will deal with have the form
+ * ConnectionIO[A], specifying computations that take place in a context where a
+ * java.sql.Connection is available, ultimately producing a value of type A.
+ *
+ * doobie programs are values. You can compose small programs to build larger programs. Once you
+ * have constructed a program you wish to run, you interpret it into an effectful target monad of
+ * your choice (Task or IO for example) and drop it into your main application wherever you like.
+ *
+ * ==First programs==
+ *
+ * {{{
+ * import doobie.imports._
+ * import scalaz._, Scalaz._
+ * import scalaz.concurrent.Task
+ * }}}
+ *
+ * So let’s start with a ConnectionIO program that simply returns a constant.
+ *
+ * {{{
+ * val program = 42.point[ConnectionIO]
+ * program: ConnectionIO[Int] = Return(42)
+ * }}}
+ *
+ * This is a perfectly respectable doobie program, but we can’t run it as-is; we need a Connection
+ * first. There are several ways to do this, but here let’s use a Transactor.
+ *
+ * {{{
+ * val xa = DriverManagerTransactor[Task](
+ * driver = "org.postgresql.Driver",
+ * url = "jdbc:postgresql:world",
+ * user = "postgres",
+ * pass = ""
+ * )
+ * }}}
+ *
+ * A Transactor is simply a structure that knows how to connect to a database, hand out
+ * connections, and clean them up; and with this knowledge it can transform ConnectionIO ~> Task,
+ * which gives us something we can run. Specifically it gives us a Task that, when run, will
+ * connect to the database and run our program in a single transaction.
+ *
+ * The DriverManagerTransactor simply delegates to the java.sql.DriverManager to allocate
+ * connections, which is fine for development but inefficient for production use.
+ *
+ * @param name connecting_to_database
+ */
 object ConnectingToDatabaseSection extends FlatSpec with Matchers with Section {
 
   /**
-    * Right, so let’s do this.
-    */
-    def constantValue(res0: Int) =
+   * Right, so let’s do this.
+   */
+  def constantValue(res0: Int) =
     42.point[ConnectionIO].transact(xa).run should be(res0)
 
   /** We have computed a constant. It’s not very interesting because we never ask the database to
-    * perform any work, but it’s a first step
-    *
-    * We are gonna connect to a database to compute a constant.
-    * Let’s use the sql string interpolator to construct a query that asks the database to compute
-    * a constant. The meaning of this program is “run the query, interpret the resultset as
-    * a stream of Int values, and yield its one and only element.”
-    */
+   * perform any work, but it’s a first step
+   *
+   * We are gonna connect to a database to compute a constant.
+   * Let’s use the sql string interpolator to construct a query that asks the database to compute
+   * a constant. The meaning of this program is “run the query, interpret the resultset as
+   * a stream of Int values, and yield its one and only element.”
+   */
   def constantValueFromDatabase(res0: Int) =
     sql"select 42".query[Int].unique.transact(xa).run should be(res0)
 
   /** What if we want to do more than one thing in a transaction? Easy! ConnectionIO is a monad,
-    * so we can use a for comprehension to compose two smaller programs into one larger program.
-    */
+   * so we can use a for comprehension to compose two smaller programs into one larger program.
+   */
   def combineTwoPrograms(res0: (Int, Int)) = {
     val largerProgram = for {
       a <- sql"select 42".query[Int].unique
@@ -89,10 +94,10 @@ object ConnectingToDatabaseSection extends FlatSpec with Matchers with Section {
   }
 
   /** The astute among you will note that we don’t actually need a monad to do this; an applicative
-    * functor is all we need here. So we could also write the above program as:
-    */
+   * functor is all we need here. So we could also write the above program as:
+   */
   def combineTwoProgramsWithApplicative(res0: Int) = {
-    val oneProgram = sql"select 42".query[Int].unique
+    val oneProgram     = sql"select 42".query[Int].unique
     val anotherProgram = sql"select power(5, 2)".query[Int].unique
 
     (oneProgram |@| anotherProgram) { _ + _ }.transact(xa).run should be(res0)

--- a/src/main/scala/doobie/DoobieLibrary.scala
+++ b/src/main/scala/doobie/DoobieLibrary.scala
@@ -1,14 +1,18 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import org.scalaexercises.definitions.{Library, Section}
 
 /** doobie is a pure functional JDBC layer for Scala.
-  *
-  * @param name doobie
-  */
-
+ *
+ * @param name doobie
+ */
 object DoobieLibrary extends Library {
-  override def owner: String = "scala-exercises"
+  override def owner: String      = "scala-exercises"
   override def repository: String = "exercises-doobie"
 
   override def color = Some("#E35E31")

--- a/src/main/scala/doobie/DoobieUtils.scala
+++ b/src/main/scala/doobie/DoobieUtils.scala
@@ -1,9 +1,14 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import java.sql.Connection
 
 import doobie.Model._
-import doobie.free.{ drivermanager => FD }
+import doobie.free.{drivermanager => FD}
 import doobie.imports._
 
 import scalaz.concurrent.Task

--- a/src/main/scala/doobie/ErrorHandlingSection.scala
+++ b/src/main/scala/doobie/ErrorHandlingSection.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import doobie.DoobieUtils.PersonTable._
@@ -9,94 +14,95 @@ import org.scalatest.{FlatSpec, Matchers}
 import scalaz._
 
 /**
-  * ==About Exceptions==
-  * '''doobie''' allows exceptions to propagate and escape unless they are handled explicitly
-  * (exactly as `IO` and `Task` work). This means when a '''doobie''' action (transformed to some
-  * target monad) is executed, exceptions can escape.
-  *
-  * ==The Catchable Typeclass and Derived Combinators==
-  * All '''doobie''' monads have associated instances of the `scalaz.Catchable` typeclass, and the
-  * provided interpreter requires all target monads to have an instance as well. `Catchable`
-  * provides two operations:
-  *
-  *  - `attempt` converts `M[A]` into `M[Throwable \/ A]`
-  *  - `fail` constructs an `M[A]` that fails with a provided `Throwable`
-  *
-  * So any '''doobie''' program can be lifted into a disjunction simply by adding `.attempt`.
-  *
-  * {{{
-  *   scala> val p = 42.point[ConnectionIO]
-  *   p: doobie.imports.ConnectionIO[Int] = Return(42)
-  *
-  *   scala> p.attempt
-  *   res2: doobie.imports.ConnectionIO[scalaz.\/[Throwable,Int]] = Suspend(Attempt(Return(42)))
-  * }}}
-  *
-  * From the `.attempt` combinator we derive the following, available as combinators and as syntax:
-  *
-  *  - `attemptSome` allows you to catch only specified `Throwable`s.
-  *  - `except` recovers with a new action.
-  *  - `exceptSome` same, but only for specified `Throwable`s.
-  *  - `onException` executes an action on failure, discarding its result.
-  *  - `ensuring` executes an action in all cases, generalizing `finally`.
-  *
-  * From these we can derive combinators that only pay attention to `SQLException`:
-  *
-  *  - `attemptSql` is like `attempt` but only traps `SQLException`.
-  *  - `attemptSomeSql` traps only specified `SQLException`s.
-  *  - `exceptSql` recovers from a SQLException with a new action.
-  *  - `onSqlException` executes an action on `SQLException` and discards its result.
-  *
-  * And finally we have a set of combinators that focus on SQLStates.
-  *
-  *  - `attemptSqlState` is like `attemptSql` but yields `M[SQLState \/ A]`.
-  *  - `attemptSomeSqlState` traps only specified `SQLState`s.
-  *  - `exceptSqlState` recovers from a `SQLState` with a new action.
-  *  - `exceptSomeSqlState` recovers from specified `SQLState`s with a new action.
-  *
-  * @param name error_handling
-  */
+ * ==About Exceptions==
+ * '''doobie''' allows exceptions to propagate and escape unless they are handled explicitly
+ * (exactly as `IO` and `Task` work). This means when a '''doobie''' action (transformed to some
+ * target monad) is executed, exceptions can escape.
+ *
+ * ==The Catchable Typeclass and Derived Combinators==
+ * All '''doobie''' monads have associated instances of the `scalaz.Catchable` typeclass, and the
+ * provided interpreter requires all target monads to have an instance as well. `Catchable`
+ * provides two operations:
+ *
+ *  - `attempt` converts `M[A]` into `M[Throwable \/ A]`
+ *  - `fail` constructs an `M[A]` that fails with a provided `Throwable`
+ *
+ * So any '''doobie''' program can be lifted into a disjunction simply by adding `.attempt`.
+ *
+ * {{{
+ *   scala> val p = 42.point[ConnectionIO]
+ *   p: doobie.imports.ConnectionIO[Int] = Return(42)
+ *
+ *   scala> p.attempt
+ *   res2: doobie.imports.ConnectionIO[scalaz.\/[Throwable,Int]] = Suspend(Attempt(Return(42)))
+ * }}}
+ *
+ * From the `.attempt` combinator we derive the following, available as combinators and as syntax:
+ *
+ *  - `attemptSome` allows you to catch only specified `Throwable`s.
+ *  - `except` recovers with a new action.
+ *  - `exceptSome` same, but only for specified `Throwable`s.
+ *  - `onException` executes an action on failure, discarding its result.
+ *  - `ensuring` executes an action in all cases, generalizing `finally`.
+ *
+ * From these we can derive combinators that only pay attention to `SQLException`:
+ *
+ *  - `attemptSql` is like `attempt` but only traps `SQLException`.
+ *  - `attemptSomeSql` traps only specified `SQLException`s.
+ *  - `exceptSql` recovers from a SQLException with a new action.
+ *  - `onSqlException` executes an action on `SQLException` and discards its result.
+ *
+ * And finally we have a set of combinators that focus on SQLStates.
+ *
+ *  - `attemptSqlState` is like `attemptSql` but yields `M[SQLState \/ A]`.
+ *  - `attemptSomeSqlState` traps only specified `SQLState`s.
+ *  - `exceptSqlState` recovers from a `SQLState` with a new action.
+ *  - `exceptSomeSqlState` recovers from specified `SQLState`s with a new action.
+ *
+ * @param name error_handling
+ */
 object ErrorHandlingSection extends FlatSpec with Matchers with Section {
 
   /**
-    * Let's do some exercises where errors will happen and see how to deal with them.
-    *
-    * We're going to work with `person` table again, where the `name` column is marked as being
-    * unique.
-    *
-    * {{{
-    *     CREATE TABLE IF NOT EXISTS person (
-    *     id   IDENTITY,
-    *     name VARCHAR NOT NULL UNIQUE,
-    *     age  INT
-    *     )
-    * }}}
-    *
-    * Alright, let’s define a way to insert instances.
-    *
-    * {{{
-    *     def insert(n: String, a: Option[Int]): ConnectionIO[Long] =
-    *     sql"insert into person (name, age) values ($n, $a)"
-    *     .update
-    *     .withUniqueGeneratedKeys("id")
-    * }}}
-    *
-    * The following exercises will try to insert two people with the same name. The second
-    * operation will fail with a unique constraint violation. Let's see how we can avoid this
-    * error by using several combinators.
-    *
-    * A first approach could be to specify the `Throwable` that we want to trap by using
-    * `attemptSome` combinator.
-    */
+   * Let's do some exercises where errors will happen and see how to deal with them.
+   *
+   * We're going to work with `person` table again, where the `name` column is marked as being
+   * unique.
+   *
+   * {{{
+   *     CREATE TABLE IF NOT EXISTS person (
+   *     id   IDENTITY,
+   *     name VARCHAR NOT NULL UNIQUE,
+   *     age  INT
+   *     )
+   * }}}
+   *
+   * Alright, let’s define a way to insert instances.
+   *
+   * {{{
+   *     def insert(n: String, a: Option[Int]): ConnectionIO[Long] =
+   *     sql"insert into person (name, age) values ($n, $a)"
+   *     .update
+   *     .withUniqueGeneratedKeys("id")
+   * }}}
+   *
+   * The following exercises will try to insert two people with the same name. The second
+   * operation will fail with a unique constraint violation. Let's see how we can avoid this
+   * error by using several combinators.
+   *
+   * A first approach could be to specify the `Throwable` that we want to trap by using
+   * `attemptSome` combinator.
+   */
   def safeInsertWithAttemptSome(res0: String \/ Long) = {
 
-    def safeInsert(name: String, age: Option[Int]): ConnectionIO[String \/ Long] = insert(name, age)
-      .attemptSome {
-        case e: java.sql.SQLException => "Oops!"
-      }
+    def safeInsert(name: String, age: Option[Int]): ConnectionIO[String \/ Long] =
+      insert(name, age)
+        .attemptSome {
+          case e: java.sql.SQLException => "Oops!"
+        }
 
     val insertedRows = for {
-      john <- safeInsert("John", Option(35))
+      john      <- safeInsert("John", Option(35))
       otherJohn <- safeInsert("John", Option(20))
     } yield otherJohn
 
@@ -108,23 +114,24 @@ object ErrorHandlingSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * If we want to trap a specific `SqlState` like `unique constraint violation`, we'll use the
-    * `attemptSomeSqlState`. We can specify several `SqlState` values and indicate what value we'll
-    * return in each case. We can:
-    *
-    *  - Use the `SqlState` values provided as constants in the contrib-postgresql add-on
-    *  - Create a new `SqlState` value by typing `val UNIQUE_VIOLATION = SqlState("23505")`
-    */
+   * If we want to trap a specific `SqlState` like `unique constraint violation`, we'll use the
+   * `attemptSomeSqlState`. We can specify several `SqlState` values and indicate what value we'll
+   * return in each case. We can:
+   *
+   *  - Use the `SqlState` values provided as constants in the contrib-postgresql add-on
+   *  - Create a new `SqlState` value by typing `val UNIQUE_VIOLATION = SqlState("23505")`
+   */
   def safeInsertWithAttemptSomeSqlState(res0: String \/ Long) = {
 
-    def safeInsert(name: String, age: Option[Int]): ConnectionIO[String \/ Long] = insert(name, age)
-      .attemptSomeSqlState {
-        case FOREIGN_KEY_VIOLATION => "Another error"
-        case UNIQUE_VIOLATION => "John is already here!"
-      }
+    def safeInsert(name: String, age: Option[Int]): ConnectionIO[String \/ Long] =
+      insert(name, age)
+        .attemptSomeSqlState {
+          case FOREIGN_KEY_VIOLATION => "Another error"
+          case UNIQUE_VIOLATION      => "John is already here!"
+        }
 
     val insertedRows = for {
-      john <- safeInsert("John", Option(35))
+      john      <- safeInsert("John", Option(35))
       otherJohn <- safeInsert("John", Option(20))
     } yield otherJohn
 
@@ -136,20 +143,21 @@ object ErrorHandlingSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * Finally we can recover from an error with a new action by using `exceptSqlState`. In this
-    * case, if the name already exists, we'll insert the person with a different name.
-    */
+   * Finally we can recover from an error with a new action by using `exceptSqlState`. In this
+   * case, if the name already exists, we'll insert the person with a different name.
+   */
   def safeInsertWithExceptSqlState(res0: String, res1: Option[Int]) = {
 
-    def safeInsert(name: String, age: Option[Int]): ConnectionIO[Long] = insert(name, age)
-      .exceptSqlState {
-        case UNIQUE_VIOLATION => insert(name + "_20", age)
-      }
+    def safeInsert(name: String, age: Option[Int]): ConnectionIO[Long] =
+      insert(name, age)
+        .exceptSqlState {
+          case UNIQUE_VIOLATION => insert(name + "_20", age)
+        }
 
     val insertedRows = for {
-      john <- safeInsert("John", Option(35))
+      john      <- safeInsert("John", Option(35))
       otherJohn <- safeInsert("John", Option(20))
-      info <- findPersonById(otherJohn)
+      info      <- findPersonById(otherJohn)
     } yield info
 
     val result = insertedRows

--- a/src/main/scala/doobie/ErrorHandlingSectionHelpers.scala
+++ b/src/main/scala/doobie/ErrorHandlingSectionHelpers.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import doobie.enum.sqlstate.SqlState
@@ -6,13 +11,12 @@ import doobie.imports._
 object ErrorHandlingSectionHelpers {
 
   val FOREIGN_KEY_VIOLATION = SqlState("23503")
-  val UNIQUE_VIOLATION = SqlState("23505")
+  val UNIQUE_VIOLATION      = SqlState("23505")
 
   case class PersonInfo(name: String, age: Option[Int])
 
   def insert(s: String, a: Option[Int]): ConnectionIO[Long] =
-    sql"insert into person (name, age) values ($s, $a)"
-      .update
+    sql"insert into person (name, age) values ($s, $a)".update
       .withUniqueGeneratedKeys("id")
 
   def findPersonById(id: Long): ConnectionIO[PersonInfo] =

--- a/src/main/scala/doobie/Model.scala
+++ b/src/main/scala/doobie/Model.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 object Model {

--- a/src/main/scala/doobie/MultiColumnQueriesSection.scala
+++ b/src/main/scala/doobie/MultiColumnQueriesSection.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import doobie.DoobieUtils.CountryTable._
@@ -9,30 +14,30 @@ import shapeless.record._
 import shapeless.{::, HNil}
 
 /**
-  * So far, we have constructed queries that return single-column results. These results were mapped
-  * to Scala types. But how can we deal with multi-column queries?
-  *
-  * In this section, we'll see what alternatives '''doobie''' offers us to work with multi-column
-  * queries.
-  *
-  * As in previous sections, we'll keep working with the 'country' table:
-  * {{{
-  * code    name                      population    gnp
-  * "DEU"  "Germany"                    82164700    2133367.00
-  * "ESP"  "Spain"                      39441700          null
-  * "FRA"  "France",                    59225700    1424285.00
-  * "GBR"  "United Kingdom"             59623400    1378330.00
-  * "USA"  "United States of America"  278357000    8510700.00
-  * }}}
-  *
-  * @param name multi_column_queries
-  */
+ * So far, we have constructed queries that return single-column results. These results were mapped
+ * to Scala types. But how can we deal with multi-column queries?
+ *
+ * In this section, we'll see what alternatives '''doobie''' offers us to work with multi-column
+ * queries.
+ *
+ * As in previous sections, we'll keep working with the 'country' table:
+ * {{{
+ * code    name                      population    gnp
+ * "DEU"  "Germany"                    82164700    2133367.00
+ * "ESP"  "Spain"                      39441700          null
+ * "FRA"  "France",                    59225700    1424285.00
+ * "GBR"  "United Kingdom"             59623400    1378330.00
+ * "USA"  "United States of America"  278357000    8510700.00
+ * }}}
+ *
+ * @param name multi_column_queries
+ */
 object MultiColumnQueriesSection extends FlatSpec with Matchers with Section {
 
   /**
-    * We can select multiple columns and map them to a tuple. The `gnp` column in our table is
-    * nullable so we’ll select that one into an `Option[Double]`.
-    */
+   * We can select multiple columns and map them to a tuple. The `gnp` column in our table is
+   * nullable so we’ll select that one into an `Option[Double]`.
+   */
   def selectMultipleColumnsUsingTuple(res0: Option[Double]) = {
 
     val (name, population, gnp) =
@@ -46,10 +51,10 @@ object MultiColumnQueriesSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * doobie automatically supports row mappings for atomic column types, as well as options,
-    * tuples, `HList`s, shapeless records, and case classes thereof. So let’s try the same query
-    * with an `HList`
-    */
+   * doobie automatically supports row mappings for atomic column types, as well as options,
+   * tuples, `HList`s, shapeless records, and case classes thereof. So let’s try the same query
+   * with an `HList`
+   */
   def selectMultipleColumnsUsingHList(res0: String) = {
 
     type CountryHListType = String :: Int :: Option[Double] :: HNil
@@ -65,8 +70,8 @@ object MultiColumnQueriesSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * And with a shapeless record:
-    */
+   * And with a shapeless record:
+   */
   def selectMultipleColumnsUsingRecord(res0: Int) = {
 
     type Rec = Record.`'name -> String, 'pop -> Int, 'gnp -> Option[Double]`.T
@@ -82,12 +87,12 @@ object MultiColumnQueriesSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * And again, mapping rows to a case class.
-    *
-    * {{{
-    * case class Country(code: String, name: String, population: Long, gnp: Option[Double])
-    * }}}
-    */
+   * And again, mapping rows to a case class.
+   *
+   * {{{
+   * case class Country(code: String, name: String, population: Long, gnp: Option[Double])
+   * }}}
+   */
   def selectMultipleColumnsUsingCaseClass(res0: String) = {
 
     val country =
@@ -101,15 +106,15 @@ object MultiColumnQueriesSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * You can also nest case classes, `HList`s, shapeless records, and/or tuples arbitrarily as long
-    * as the eventual members are of supported columns types. For instance, here we map the same set
-    * of columns to a tuple of two case classes:
-    *
-    * {{{
-    * case class Code(code: String)
-    * case class CountryInfo(name: String, pop: Int, gnp: Option[Double])
-    * }}}
-    */
+   * You can also nest case classes, `HList`s, shapeless records, and/or tuples arbitrarily as long
+   * as the eventual members are of supported columns types. For instance, here we map the same set
+   * of columns to a tuple of two case classes:
+   *
+   * {{{
+   * case class Code(code: String)
+   * case class CountryInfo(name: String, pop: Int, gnp: Option[Double])
+   * }}}
+   */
   def selectMultipleColumnsUsingNestedCaseClass(res0: String) = {
 
     val (code, country) =
@@ -123,9 +128,9 @@ object MultiColumnQueriesSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * And just for fun, since the `Code` values are constructed from the primary key, let’s turn the
-    * results into a `Map`. Trivial but useful.
-    */
+   * And just for fun, since the `Code` values are constructed from the primary key, let’s turn the
+   * results into a `Map`. Trivial but useful.
+   */
   def selectMultipleColumnsUsingMap(res0: String, res1: Option[CountryInfo]) = {
 
     val notFoundCountry = CountryInfo("Not Found", 0, None)

--- a/src/main/scala/doobie/ParameterizedQueriesSection.scala
+++ b/src/main/scala/doobie/ParameterizedQueriesSection.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import doobie.DoobieUtils.CountryTable._
@@ -10,49 +15,48 @@ import org.scalatest.{FlatSpec, Matchers}
 import scalaz.NonEmptyList
 
 /**
-  * Previously we have worked with static SQL queries where the values used to filter data were
-  * hard-coded and didn't change.
-  *
-  * {{{
-  *   select code, name, population, gnp from country where code = "GBR"
-  * }}}
-  *
-  * In this section, we'll learn how to construct parameterized queries.
-  *
-  * We’re still playing with the country table, shown here for reference.
-  * {{{
-  * code    name                      population    gnp
-  * "DEU"  "Germany"                    82164700    2133367.00
-  * "ESP"  "Spain"                      39441700          null
-  * "FRA"  "France",                    59225700    1424285.00
-  * "GBR"  "United Kingdom"             59623400    1378330.00
-  * "USA"  "United States of America"  278357000    8510700.00
-  * }}}
-  *
-  * @param name parameterized_queries
-  */
+ * Previously we have worked with static SQL queries where the values used to filter data were
+ * hard-coded and didn't change.
+ *
+ * {{{
+ *   select code, name, population, gnp from country where code = "GBR"
+ * }}}
+ *
+ * In this section, we'll learn how to construct parameterized queries.
+ *
+ * We’re still playing with the country table, shown here for reference.
+ * {{{
+ * code    name                      population    gnp
+ * "DEU"  "Germany"                    82164700    2133367.00
+ * "ESP"  "Spain"                      39441700          null
+ * "FRA"  "France",                    59225700    1424285.00
+ * "GBR"  "United Kingdom"             59623400    1378330.00
+ * "USA"  "United States of America"  278357000    8510700.00
+ * }}}
+ *
+ * @param name parameterized_queries
+ */
 object ParameterizedQueriesSection extends FlatSpec with Matchers with Section {
 
   /**
-    * == Adding a Parameter ==
-    *
-    * Let’s factor our query into a method and add a parameter that selects only the countries with
-    * a population larger than some value the user will provide. We insert the minPop argument into
-    * our SQL statement as $minPop, just as if we were doing string interpolation.
-    * {{{
-    *   def biggerThan(minPop: Int) =
-    *   sql"""
-    *     select code, name, population, gnp
-    *     from country
-    *     where population > $minPop
-    *     order by population asc
-    *   """.query[Country]
-    * }}}
-    */
+   * == Adding a Parameter ==
+   *
+   * Let’s factor our query into a method and add a parameter that selects only the countries with
+   * a population larger than some value the user will provide. We insert the minPop argument into
+   * our SQL statement as $minPop, just as if we were doing string interpolation.
+   * {{{
+   *   def biggerThan(minPop: Int) =
+   *   sql"""
+   *     select code, name, population, gnp
+   *     from country
+   *     where population > $minPop
+   *     order by population asc
+   *   """.query[Country]
+   * }}}
+   */
   def addingAParameter(res0: String, res1: String) = {
 
-    val countriesName = biggerThan(75000000)
-      .list
+    val countriesName = biggerThan(75000000).list
       .transact(xa)
       .run
       .map(_.name)
@@ -61,34 +65,33 @@ object ParameterizedQueriesSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * So what’s going on? It looks like we’re just dropping a string literal into our SQL string,
-    * but actually we’re constructing a proper parameterized PreparedStatement, and the minProp
-    * value is ultimately set via a call to setInt
-    *
-    * '''doobie''' allows you to interpolate values of any type with a `Atom` instance, which
-    * includes:
-    *  - any JVM type that has a target mapping defined by the JDBC specification,
-    *  - vendor-specific types defined by extension packages,
-    *  - custom column types that you define, and
-    *  - single-member products (case classes, typically) of any of the above.
-    *
-    * == Multiple Parameters ==
-    *
-    * Multiple parameters work the same way.
-    * {{{
-    *   def populationIn(range: Range) =
-    *   sql"""
-    *     select code, name, population, gnp
-    *     from country
-    *     where population > ${range.min} and population < ${range.max}
-    *     order by population asc
-    *   """.query[Country]
-    * }}}
-    */
+   * So what’s going on? It looks like we’re just dropping a string literal into our SQL string,
+   * but actually we’re constructing a proper parameterized PreparedStatement, and the minProp
+   * value is ultimately set via a call to setInt
+   *
+   * '''doobie''' allows you to interpolate values of any type with a `Atom` instance, which
+   * includes:
+   *  - any JVM type that has a target mapping defined by the JDBC specification,
+   *  - vendor-specific types defined by extension packages,
+   *  - custom column types that you define, and
+   *  - single-member products (case classes, typically) of any of the above.
+   *
+   * == Multiple Parameters ==
+   *
+   * Multiple parameters work the same way.
+   * {{{
+   *   def populationIn(range: Range) =
+   *   sql"""
+   *     select code, name, population, gnp
+   *     from country
+   *     where population > ${range.min} and population < ${range.max}
+   *     order by population asc
+   *   """.query[Country]
+   * }}}
+   */
   def addingMultipleParameters(res0: String, res1: String, res2: String) = {
 
-    val countriesName = populationIn(25000000 to 75000000)
-      .list
+    val countriesName = populationIn(25000000 to 75000000).list
       .transact(xa)
       .run
       .map(_.name)
@@ -97,36 +100,35 @@ object ParameterizedQueriesSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * == Dealing with IN Clauses ==
-    *
-    * A common irritant when dealing with SQL literals is the desire to inline a sequence of
-    * arguments into an IN clause, but SQL does not support this notion (nor does JDBC do anything
-    * to assist). So as of version 0.2.3 doobie provides support in the form of some slightly
-    * inconvenient machinery.
-    * {{{
-    *   def populationIn(range: Range, codes: NonEmptyList[String]) = {
-    *     implicit val codesParam = Param.many(codes)
-    *     sql"""
-    *       select code, name, population, gnp
-    *       from country
-    *       where population > ${range.min}
-    *       and   population < ${range.max}
-    *       and   code in (${codes : codes.type})
-    *     """.query[Country]
-    *   }
-    * }}}
-    *
-    * There are a few things to notice here:
-    *  - The `IN` clause must be non-empty, so `codes` is a `NonEmptyList`.
-    *  - We must derive a `Param` instance for the singleton type of `codes`, which we do via
-    *  `Param.many`. This derivation is legal for any `F[A]` given `Foldable1[F]` and `Atom[A]`. You
-    *  can have any number of `IN` arguments but each must have its own derived `Param` instance.
-    *  - When interpolating `codes` we must explicitly ascribe its singleton type `codes.type`.
-    */
+   * == Dealing with IN Clauses ==
+   *
+   * A common irritant when dealing with SQL literals is the desire to inline a sequence of
+   * arguments into an IN clause, but SQL does not support this notion (nor does JDBC do anything
+   * to assist). So as of version 0.2.3 doobie provides support in the form of some slightly
+   * inconvenient machinery.
+   * {{{
+   *   def populationIn(range: Range, codes: NonEmptyList[String]) = {
+   *     implicit val codesParam = Param.many(codes)
+   *     sql"""
+   *       select code, name, population, gnp
+   *       from country
+   *       where population > ${range.min}
+   *       and   population < ${range.max}
+   *       and   code in (${codes : codes.type})
+   *     """.query[Country]
+   *   }
+   * }}}
+   *
+   * There are a few things to notice here:
+   *  - The `IN` clause must be non-empty, so `codes` is a `NonEmptyList`.
+   *  - We must derive a `Param` instance for the singleton type of `codes`, which we do via
+   *  `Param.many`. This derivation is legal for any `F[A]` given `Foldable1[F]` and `Atom[A]`. You
+   *  can have any number of `IN` arguments but each must have its own derived `Param` instance.
+   *  - When interpolating `codes` we must explicitly ascribe its singleton type `codes.type`.
+   */
   def dealingWithInClause(res0: String, res1: String) = {
 
-    val countriesName = populationIn(25000000 to 75000000, NonEmptyList("ESP","USA","FRA"))
-      .list
+    val countriesName = populationIn(25000000 to 75000000, NonEmptyList("ESP", "USA", "FRA")).list
       .transact(xa)
       .run
       .map(_.name)

--- a/src/main/scala/doobie/ParameterizedQueryHelpers.scala
+++ b/src/main/scala/doobie/ParameterizedQueryHelpers.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import doobie.Model.Country
@@ -15,8 +20,12 @@ object ParameterizedQueryHelpers {
       .query[Country]
 
   def populationIn(range: Range, codes: NonEmptyList[String]) = {
-    implicit val codesParam = Param.many(codes)
-    sql"select code, name, population, gnp from country where population > ${range.min} and population < ${range.max} and code in (${codes: codes.type}) order by population asc"
-      .query[Country]
+    val q = fr"""
+    select code, name, population, gnp
+    from country
+    where population > ${range.min}
+    and   population < ${range.max}
+    and   """ ++ Fragments.in(fr"code", codes) // code IN (...)
+    q.query[Country]
   }
 }

--- a/src/main/scala/doobie/SelectingDataSection.scala
+++ b/src/main/scala/doobie/SelectingDataSection.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import doobie.DoobieUtils.CountryTable._
@@ -6,63 +11,63 @@ import org.scalaexercises.definitions.Section
 import org.scalatest.{FlatSpec, Matchers}
 
 /**
-  * We are going to construct some programs that retrieve data from the database and stream it back,
-  * mapping to Scala types on the way.
-  *
-  * We will be playing with the country table that has the following structure:
-  * {{{
-  * CREATE TABLE country (
-  * code       character(3)  NOT NULL,
-  * name       text          NOT NULL,
-  * population integer       NOT NULL,
-  * gnp        numeric(10,2)
-  * )
-  * }}}
-  *
-  * For the exercises, the ''country'' table will contain:
-  * {{{
-  * code    name                      population    gnp
-  * "DEU"  "Germany"                    82164700    2133367.00
-  * "ESP"  "Spain"                      39441700          null
-  * "FRA"  "France",                    59225700    1424285.00
-  * "GBR"  "United Kingdom"             59623400    1378330.00
-  * "USA"  "United States of America"  278357000    8510700.00
-  * }}}
-  *
-  * == How to select data ==
-  *
-  * As we commented in the previous section, the `sql` string interpolator allow us to create a
-  * query to select data from the database.
-  *
-  * For instance, `sql"select name from country".query[String]` defines a `Query0[String]`, which
-  * is a one-column query that maps each returned row to a String.
-  *
-  * Once we generate this query, we could use several convenience methods to stream the results:
-  *  - `.list`, which accumulates the results to a `List`, in this case yielding a
-  * `ConnectionIO[List[String]]`.
-  *  - `.vector`, which accumulates to a `Vector`
-  *  - `.to[Coll]`, which accumulates to a type `Coll`, given an implicit `CanBuildFrom`. This works
-  * with Scala standard library collections.
-  *  - `.accumulate[M[_]: MonadPlus]` which accumulates to a universally quantified monoid `M`.
-  * This works with many scalaz collections, as well as standard library collections with
-  * `MonadPlus` instances.
-  *  - `.unique` which returns a single value, raising an exception if there is not exactly
-  * one row returned.
-  *  - `.option` which returns an Option, raising an exception if there is more than
-  * one row returned.
-  *  - `.nel` which returns an `NonEmptyList`, raising an exception if there are no rows returned.
-  *  - See the Scaladoc for [[http://tpolecat.github.io/doc/doobie/0.3.0/api/index.html#doobie.util.query$$Query0 `Query0`]]
-  * for more information on these and other methods.
-  *
-  * @param name selecting_data
-  */
+ * We are going to construct some programs that retrieve data from the database and stream it back,
+ * mapping to Scala types on the way.
+ *
+ * We will be playing with the country table that has the following structure:
+ * {{{
+ * CREATE TABLE country (
+ * code       character(3)  NOT NULL,
+ * name       text          NOT NULL,
+ * population integer       NOT NULL,
+ * gnp        numeric(10,2)
+ * )
+ * }}}
+ *
+ * For the exercises, the ''country'' table will contain:
+ * {{{
+ * code    name                      population    gnp
+ * "DEU"  "Germany"                    82164700    2133367.00
+ * "ESP"  "Spain"                      39441700          null
+ * "FRA"  "France",                    59225700    1424285.00
+ * "GBR"  "United Kingdom"             59623400    1378330.00
+ * "USA"  "United States of America"  278357000    8510700.00
+ * }}}
+ *
+ * == How to select data ==
+ *
+ * As we commented in the previous section, the `sql` string interpolator allow us to create a
+ * query to select data from the database.
+ *
+ * For instance, `sql"select name from country".query[String]` defines a `Query0[String]`, which
+ * is a one-column query that maps each returned row to a String.
+ *
+ * Once we generate this query, we could use several convenience methods to stream the results:
+ *  - `.list`, which accumulates the results to a `List`, in this case yielding a
+ * `ConnectionIO[List[String]]`.
+ *  - `.vector`, which accumulates to a `Vector`
+ *  - `.to[Coll]`, which accumulates to a type `Coll`, given an implicit `CanBuildFrom`. This works
+ * with Scala standard library collections.
+ *  - `.accumulate[M[_]: MonadPlus]` which accumulates to a universally quantified monoid `M`.
+ * This works with many scalaz collections, as well as standard library collections with
+ * `MonadPlus` instances.
+ *  - `.unique` which returns a single value, raising an exception if there is not exactly
+ * one row returned.
+ *  - `.option` which returns an Option, raising an exception if there is more than
+ * one row returned.
+ *  - `.nel` which returns an `NonEmptyList`, raising an exception if there are no rows returned.
+ *  - See the Scaladoc for [[http://tpolecat.github.io/doc/doobie/0.3.0/api/index.html#doobie.util.query$$Query0 `Query0`]]
+ * for more information on these and other methods.
+ *
+ * @param name selecting_data
+ */
 object SelectingDataSection extends FlatSpec with Matchers with Section {
 
   /**
-    * == Getting info about the countries ==
-    *
-    * We can use the `unique` method if we expect the query to return only one row
-    */
+   * == Getting info about the countries ==
+   *
+   * We can use the `unique` method if we expect the query to return only one row
+   */
   def selectUniqueCountryName(res0: String) = {
 
     val countryName =
@@ -76,8 +81,8 @@ object SelectingDataSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * If we are not sure if the record exists, we can use the `option` method.
-    */
+   * If we are not sure if the record exists, we can use the `option` method.
+   */
   def selectOptionalCountryName(res0: Option[String]) = {
 
     val maybeCountryName =
@@ -91,9 +96,9 @@ object SelectingDataSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * When the query can return more than one row, we can use the `list` to accumulate the results
-    * in a List.
-    */
+   * When the query can return more than one row, we can use the `list` to accumulate the results
+   * in a List.
+   */
   def selectCountryNameList(res0: String) = {
 
     val countryNames =
@@ -107,15 +112,15 @@ object SelectingDataSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * This is ok, but there’s not much point reading all the results from the database when we only
-    * want the first few rows.
-    *
-    * A different approach could be to use the `process` that  gives us a
-    * `scalaz.stream.Process[ConnectionIO, String]` which emits the results as they arrive from the
-    * database. By applying a limit with `take` we instruct the process to shut everything down
-    * (and clean everything up) after the required number of elements have been emitted. This is
-    * much more efficient than pulling all the rows of the table and then throwing most of them away.
-    */
+   * This is ok, but there’s not much point reading all the results from the database when we only
+   * want the first few rows.
+   *
+   * A different approach could be to use the `process` that  gives us a
+   * `scalaz.stream.Process[ConnectionIO, String]` which emits the results as they arrive from the
+   * database. By applying a limit with `take` we instruct the process to shut everything down
+   * (and clean everything up) after the required number of elements have been emitted. This is
+   * much more efficient than pulling all the rows of the table and then throwing most of them away.
+   */
   def selectCountryNameListByUsingProcess(res0: Int) = {
 
     val countryNames =

--- a/src/main/scala/doobie/UpdatesSection.scala
+++ b/src/main/scala/doobie/UpdatesSection.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import doobie.DoobieUtils.PersonTable._
@@ -9,60 +14,59 @@ import org.scalatest.{FlatSpec, Matchers}
 import scalaz._, Scalaz._
 
 /**
-  * In this section we examine operations that modify data in the database, and ways to retrieve the
-  * results of these updates.
-  *
-  * ==Data Definition==
-  * It is uncommon to define database structures at runtime, but '''doobie''' handles it just fine
-  * and treats such operations like any other kind of update. And it happens to be useful here!.
-  *
-  * Let’s create a new table, which we will use for the exercises to follow. This looks a lot like
-  * our prior usage of the `sql` interpolator, but this time we’re using `update` rather than
-  * `query`. The `.run` method gives a `ConnectionIO[Int]` that yields the total number of rows
-  * modified
-  *
-  * {{{
-  * val drop: Update0 =
-  * sql"""
-  *   DROP TABLE IF EXISTS person
-  * """.update
-  *
-  * val create: Update0 =
-  * sql"""
-  *   CREATE TABLE person (
-  *     id   SERIAL,
-  *     name VARCHAR NOT NULL UNIQUE,
-  *     age  SMALLINT
-  *   )
-  * """.update
-  * }}}
-  *
-  * We can compose these and run them together.
-  * {{{
-  *   (drop.run *> create.run).transact(xa).unsafePerformSync
-  * }}}
-  *
-  * ==Inserting==
-  * Inserting is straightforward and works just as with selects. Here we define a method that
-  * constructs an `Update0` that inserts a row into the `person` table.
-  *
-  * {{{
-  *   def insert1(name: String, age: Option[Short]): Update0 =
-  *     sql"insert into person (name, age) values ($name, $age)".update
-  * }}}
-  *
-  * @param name inserting_and_updating
-  */
+ * In this section we examine operations that modify data in the database, and ways to retrieve the
+ * results of these updates.
+ *
+ * ==Data Definition==
+ * It is uncommon to define database structures at runtime, but '''doobie''' handles it just fine
+ * and treats such operations like any other kind of update. And it happens to be useful here!.
+ *
+ * Let’s create a new table, which we will use for the exercises to follow. This looks a lot like
+ * our prior usage of the `sql` interpolator, but this time we’re using `update` rather than
+ * `query`. The `.run` method gives a `ConnectionIO[Int]` that yields the total number of rows
+ * modified
+ *
+ * {{{
+ * val drop: Update0 =
+ * sql"""
+ *   DROP TABLE IF EXISTS person
+ * """.update
+ *
+ * val create: Update0 =
+ * sql"""
+ *   CREATE TABLE person (
+ *     id   SERIAL,
+ *     name VARCHAR NOT NULL UNIQUE,
+ *     age  SMALLINT
+ *   )
+ * """.update
+ * }}}
+ *
+ * We can compose these and run them together.
+ * {{{
+ *   (drop.run *> create.run).transact(xa).unsafePerformSync
+ * }}}
+ *
+ * ==Inserting==
+ * Inserting is straightforward and works just as with selects. Here we define a method that
+ * constructs an `Update0` that inserts a row into the `person` table.
+ *
+ * {{{
+ *   def insert1(name: String, age: Option[Short]): Update0 =
+ *     sql"insert into person (name, age) values ($name, $age)".update
+ * }}}
+ *
+ * @param name inserting_and_updating
+ */
 object UpdatesSection extends FlatSpec with Matchers with Section {
 
   /**
-    * Let's insert a new row by using the recently defined `insert1` method.
-    */
+   * Let's insert a new row by using the recently defined `insert1` method.
+   */
   def insertOneRow(res0: Int) = {
 
     val insertedRows =
-      insert1("John", Option(35))
-        .run
+      insert1("John", Option(35)).run
         .transact(xa)
         .run
 
@@ -70,10 +74,9 @@ object UpdatesSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * On the contrary, if we want to insert several rows, there are different ways to do that. A
-    * first try could be to use a `for-comprehension` to compose all the single operations.
-    */
-
+   * On the contrary, if we want to insert several rows, there are different ways to do that. A
+   * first try could be to use a `for-comprehension` to compose all the single operations.
+   */
   def insertSeveralRowsWithForComprehension(res0: Int) = {
 
     val rows = for {
@@ -90,16 +93,16 @@ object UpdatesSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * If there is no dependency between the SQL operations, it could be better to use an applicative
-    * functor.
-    */
+   * If there is no dependency between the SQL operations, it could be better to use an applicative
+   * functor.
+   */
   def insertSeveralRowsWithApplicativeFunctor(res0: Int) = {
 
     val insertedOnePerson = insert1("Alice", Option(12)).run
 
     val insertedOtherPerson = insert1("Bob", None).run
 
-    val insertedRows = (insertedOnePerson |@| insertedOtherPerson)(_ + _ )
+    val insertedRows = (insertedOnePerson |@| insertedOtherPerson)(_ + _)
       .transact(xa)
       .run
 
@@ -107,16 +110,13 @@ object UpdatesSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * If all the data to be inserted is represented by a `List`, other way could be by using the
-    * Scalaz `traverse` method.
-    */
+   * If all the data to be inserted is represented by a `List`, other way could be by using the
+   * Scalaz `traverse` method.
+   */
   def insertSeveralRowsWithTraverse(res0: Int) = {
 
-    val people = List(
-      ("Alice", Option(12)),
-      ("Bob", None),
-      ("John", Option(17)),
-      ("Mary", Option(16)))
+    val people =
+      List(("Alice", Option(12)), ("Bob", None), ("John", Option(17)), ("Mary", Option(16)))
 
     val insertedRows = people
       .traverse(item => (insert1 _).tupled(item).run)
@@ -127,16 +127,16 @@ object UpdatesSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * ==Updating==
-    * Updating follows the same pattern. For instance, we suppose that we want to modify the age of
-    * a person.
-    */
+   * ==Updating==
+   * Updating follows the same pattern. For instance, we suppose that we want to modify the age of
+   * a person.
+   */
   def updateExistingRow(res0: Int, res1: Int, res2: Int) = {
 
     val result = for {
       insertedRows <- insert1("Alice", Option(12)).run
-      updatedRows <- sql"update person set age = 15 where name = 'Alice'".update.run
-      person <- sql"select id, name, age from person where name = 'Alice'".query[Person].unique
+      updatedRows  <- sql"update person set age = 15 where name = 'Alice'".update.run
+      person       <- sql"select id, name, age from person where name = 'Alice'".query[Person].unique
     } yield (insertedRows, updatedRows, person)
 
     val (insertedRows, updatedRows, person) = result
@@ -149,73 +149,72 @@ object UpdatesSection extends FlatSpec with Matchers with Section {
   }
 
   /**
-    * ==Retrieving info==
-    * When we insert we usually want the new row back, so let’s do that. First we’ll do it the hard
-    * way, by inserting, getting the last used key via `lastVal()`, then selecting the indicated
-    * row.
-    * {{{
-    *   def insert2(name: String, age: Option[Short]): ConnectionIO[Person] =
-    *   for {
-    *   _  <- sql"insert into person (name, age) values ($name, $age)".update.run
-    *   id <- sql"select lastval()".query[Long].unique
-    *   p  <- sql"select id, name, age from person where id = $id".query[Person].unique
-    *   } yield p
-    * }}}
-    *
-    * This is irritating but it is supported by all databases (although the “get the last used id”
-    * function will vary by vendor).
-    *
-    * Some database (like H2) allow you to return [only] the inserted id, allowing the above
-    * operation to be reduced to two statements (see below for an explanation of
-    * `withUniqueGeneratedKeys`).
-    */
+   * ==Retrieving info==
+   * When we insert we usually want the new row back, so let’s do that. First we’ll do it the hard
+   * way, by inserting, getting the last used key via `lastVal()`, then selecting the indicated
+   * row.
+   * {{{
+   *   def insert2(name: String, age: Option[Short]): ConnectionIO[Person] =
+   *   for {
+   *   _  <- sql"insert into person (name, age) values ($name, $age)".update.run
+   *   id <- sql"select lastval()".query[Long].unique
+   *   p  <- sql"select id, name, age from person where id = $id".query[Person].unique
+   *   } yield p
+   * }}}
+   *
+   * This is irritating but it is supported by all databases (although the “get the last used id”
+   * function will vary by vendor).
+   *
+   * Some database (like H2) allow you to return [only] the inserted id, allowing the above
+   * operation to be reduced to two statements (see below for an explanation of
+   * `withUniqueGeneratedKeys`).
+   */
   def retrieveInfo(res0: String, res1: Int) = {
 
     def insert2_H2(name: String, age: Option[Int]): ConnectionIO[Person] =
       for {
-        id <- sql"insert into person (name, age) values ($name, $age)".update.withUniqueGeneratedKeys[Int]("id")
-        p  <- sql"select id, name, age from person where id = $id".query[Person].unique
+        id <- sql"insert into person (name, age) values ($name, $age)".update
+          .withUniqueGeneratedKeys[Int]("id")
+        p <- sql"select id, name, age from person where id = $id".query[Person].unique
       } yield p
 
     val person = insert2_H2("Ramone", Option(42))
       .transact(xa)
       .run
 
-
     person.name should be(res0)
     person.age should be(Option(res1))
   }
 
   /**
-    * Other databases (including PostgreSQL) provide a way to do this in one shot by returning
-    * multiple specified columns from the inserted row.
-    *
-    * {{{
-    *   def insert3(name: String, age: Option[Int]): ConnectionIO[Person] = {
-    *   sql"insert into person (name, age) values ($name, $age)"
-    *   .update.withUniqueGeneratedKeys("id", "name", "age")
-    *   }
-    * }}}
-    *
-    * The `withUniqueGeneratedKeys` specifies that we expect exactly one row back (otherwise an
-    * exception will be thrown), and requires a list of columns to return.
-    *
-    * This mechanism also works for updates, for databases that support it. In the case of multiple
-    * row updates we use `withGeneratedKeys` and get a Process[ConnectionIO, Person] back.
-    *
-    * == Batch Updates ==
-    * '''doobie''' supports batch updating via the `updateMany` and `updateManyWithGeneratedKeys`
-    * operations on the `Update` data type.
-    *
-    * By using an `Update` directly we can apply many sets of arguments to the same statement, and
-    * execute it as a single batch operation.
-    *
-    * - `updateMany` will return the updated of affected rows
-    *
-    * - For databases that support it (such as PostgreSQL) we can use `updateManyWithGeneratedKeys`
-    * to return a stream of updated rows.
-    */
-
+   * Other databases (including PostgreSQL) provide a way to do this in one shot by returning
+   * multiple specified columns from the inserted row.
+   *
+   * {{{
+   *   def insert3(name: String, age: Option[Int]): ConnectionIO[Person] = {
+   *   sql"insert into person (name, age) values ($name, $age)"
+   *   .update.withUniqueGeneratedKeys("id", "name", "age")
+   *   }
+   * }}}
+   *
+   * The `withUniqueGeneratedKeys` specifies that we expect exactly one row back (otherwise an
+   * exception will be thrown), and requires a list of columns to return.
+   *
+   * This mechanism also works for updates, for databases that support it. In the case of multiple
+   * row updates we use `withGeneratedKeys` and get a Process[ConnectionIO, Person] back.
+   *
+   * == Batch Updates ==
+   * '''doobie''' supports batch updating via the `updateMany` and `updateManyWithGeneratedKeys`
+   * operations on the `Update` data type.
+   *
+   * By using an `Update` directly we can apply many sets of arguments to the same statement, and
+   * execute it as a single batch operation.
+   *
+   * - `updateMany` will return the updated of affected rows
+   *
+   * - For databases that support it (such as PostgreSQL) we can use `updateManyWithGeneratedKeys`
+   * to return a stream of updated rows.
+   */
   def batchUpdates(res0: Int) = {
     type PersonInfo = (String, Option[Short])
 
@@ -225,9 +224,7 @@ object UpdatesSection extends FlatSpec with Matchers with Section {
     }
 
     // Some rows to insert
-    val data = List[PersonInfo](
-      ("Frank", Some(12)),
-      ("Daddy", None))
+    val data = List[PersonInfo](("Frank", Some(12)), ("Daddy", None))
 
     val insertedRows = insertMany(data)
       .transact(xa)

--- a/src/main/scala/doobie/UpdatesSectionHelpers.scala
+++ b/src/main/scala/doobie/UpdatesSectionHelpers.scala
@@ -1,7 +1,12 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import doobie.imports._
-import doobie.free.{ drivermanager => FD }
+import doobie.free.{drivermanager => FD}
 
 import java.sql.Connection
 

--- a/src/test/scala/doobie/ConnectingToDatabaseSectionSpec.scala
+++ b/src/test/scala/doobie/ConnectingToDatabaseSectionSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/doobie/ErrorHandlingSectionSpec.scala
+++ b/src/test/scala/doobie/ErrorHandlingSectionSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/doobie/MultiColumnQueriesSectionSpec.scala
+++ b/src/test/scala/doobie/MultiColumnQueriesSectionSpec.scala
@@ -1,13 +1,27 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
-import doobie.Model.CountryInfo
 import org.scalacheck.Shapeless._
+import doobie.Model.CountryInfo
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalaexercises.Test
 import org.scalatest.Spec
 import org.scalatest.prop.Checkers
 import shapeless.HNil
 
 class MultiColumnQueriesSectionSpec extends Spec with Checkers {
+
+  implicit val countryInfoArbitrary: Arbitrary[CountryInfo] = Arbitrary {
+    for {
+      name <- Gen.identifier
+      pop  <- Gen.posNum[Int]
+      gnp  <- Gen.option(Gen.posNum[Double])
+    } yield CountryInfo(name, pop, gnp)
+  }
 
   def `select multiple columns using tuple` = {
     val validResult: Option[Double] = None

--- a/src/test/scala/doobie/ParameterizedQueriesSectionSpec.scala
+++ b/src/test/scala/doobie/ParameterizedQueriesSectionSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import org.scalacheck.Shapeless._
@@ -7,7 +12,6 @@ import org.scalatest.prop.Checkers
 import shapeless.HNil
 
 class ParameterizedQueriesSectionSpec extends Spec with Checkers {
-
 
   def `adding a parameter` = {
     check(

--- a/src/test/scala/doobie/SelectingDataSectionSpec.scala
+++ b/src/test/scala/doobie/SelectingDataSectionSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/doobie/UpdatesSectionSpec.scala
+++ b/src/test/scala/doobie/UpdatesSectionSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-doobie
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package doobie
 
 import org.scalacheck.Shapeless._

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.4.0-SNAPSHOT"


### PR DESCRIPTION
This integration has no effect on the deployed application since we are releasing a snapshot new version.

There are multiples changes across the source code, most of them due to scalafmt autoformatting or file headers. The important changes here are:

* build.sbt
* project/plugins.sbt
* project/build.properties
* project/ProjectPlugin.scala
* README.md
* travis.yml
* version.sbt
* src/main/scala/doobie/ParameterizedQueryHelpers.scala
* src/test/scala/doobie/MultiColumnQueriesSectionSpec.scala

Please, @raulraja @franciscodr  could you review? Thanks!