### PR TITLE
Add order by for section dealing with in clause

### DIFF
--- a/src/main/scala/doobie/ParameterizedQueriesSection.scala
+++ b/src/main/scala/doobie/ParameterizedQueriesSection.scala
@@ -115,6 +115,7 @@ object ParameterizedQueriesSection extends FlatSpec with Matchers with Section {
    *       where population > ${range.min}
    *       and   population < ${range.max}
    *       and   code in (${codes : codes.type})
+   *       order by population asc
    *     """.query[Country]
    *   }
    * }}}


### PR DESCRIPTION
- Helps ensure the result list is sorted properly.
- Consistency with other examples returning `List`