### PR TITLE
Updated ScalaTest 3.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,8 @@ lazy val doobie = (project in file("."))
       %%("shapeless", V.shapeless),
       %%("scalatest", V.scalatest),
       %%("scalacheck", V.scalacheck),
-      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless,
+      "org.scalatestplus"          %% "scalatestplus-scalacheck"  % V.scalatestplusScheck
     )
   )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -19,7 +19,8 @@ object ProjectPlugin extends AutoPlugin {
       val doobie: String              = "0.8.6"
       val cats: String                = "2.0.0"
       val shapeless: String           = "2.3.3"
-      val scalatest: String           = "3.0.8"
+      val scalatest: String           = "3.1.0"
+      val scalatestplusScheck: String = "3.1.0.0-RC2"
       val scalacheck: String          = "1.14.2"
       val scalacheckShapeless: String = "1.2.3"
     }

--- a/src/main/scala/doobie/ConnectingToDatabaseSection.scala
+++ b/src/main/scala/doobie/ConnectingToDatabaseSection.scala
@@ -12,7 +12,8 @@ import DoobieUtils._
 import doobie.implicits._
 import doobie._
 import org.scalaexercises.definitions.Section
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /** ==Introduction==
  * doobie is a monadic API that provides a number of data types that all work the same way
@@ -96,11 +97,7 @@ import org.scalatest._
  *
  * @param name connecting_to_database
  */
-object ConnectingToDatabaseSection
-    extends FlatSpec
-    with Matchers
-    with Section
-    with BeforeAndAfterAll {
+object ConnectingToDatabaseSection extends AnyFlatSpec with Matchers with Section {
 
   /**
    * And here we go.

--- a/src/main/scala/doobie/ErrorHandlingSection.scala
+++ b/src/main/scala/doobie/ErrorHandlingSection.scala
@@ -11,7 +11,8 @@ import ErrorHandlingSectionHelpers._
 import doobie._
 import doobie.implicits._
 import org.scalaexercises.definitions.Section
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * ==About Exceptions==
@@ -79,7 +80,7 @@ import org.scalatest.{FlatSpec, Matchers}
  *
  * @param name error_handling
  **/
-object ErrorHandlingSection extends FlatSpec with Matchers with Section {
+object ErrorHandlingSection extends AnyFlatSpec with Matchers with Section {
 
   /**
    * Let's do some exercises where errors will happen and see how to deal with them.

--- a/src/main/scala/doobie/MultiColumnQueriesSection.scala
+++ b/src/main/scala/doobie/MultiColumnQueriesSection.scala
@@ -10,7 +10,8 @@ import doobie.implicits._
 import DoobieUtils.CountryTable._
 import Model._
 import org.scalaexercises.definitions.Section
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 import shapeless.record._
 import shapeless.syntax.singleton._
@@ -42,7 +43,7 @@ import shapeless.syntax.singleton._
  *
  * @param name multi_column_queries
  */
-object MultiColumnQueriesSection extends FlatSpec with Matchers with Section {
+object MultiColumnQueriesSection extends AnyFlatSpec with Matchers with Section {
 
   /**
    * We can select multiple columns and map them to a tuple. The `gnp` column in our table is

--- a/src/main/scala/doobie/ParameterizedQueriesSection.scala
+++ b/src/main/scala/doobie/ParameterizedQueriesSection.scala
@@ -10,7 +10,8 @@ import cats.data.NonEmptyList
 import DoobieUtils.CountryTable._
 import ParameterizedQueryHelpers._
 import org.scalaexercises.definitions.Section
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Previously we have worked with static SQL queries where the values used to filter data were
@@ -41,7 +42,7 @@ import org.scalatest.{FlatSpec, Matchers}
  *
  * @param name parameterized_queries
  */
-object ParameterizedQueriesSection extends FlatSpec with Matchers with Section {
+object ParameterizedQueriesSection extends AnyFlatSpec with Matchers with Section {
 
   /**
    * == Adding a Parameter ==

--- a/src/main/scala/doobie/SelectingDataSection.scala
+++ b/src/main/scala/doobie/SelectingDataSection.scala
@@ -9,7 +9,8 @@ package doobielib
 import doobie.implicits._
 import DoobieUtils.CountryTable._
 import org.scalaexercises.definitions.Section
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * We are going to construct some programs that retrieve data from the database and stream it back,
@@ -52,7 +53,7 @@ import org.scalatest.{FlatSpec, Matchers}
  *
  * @param name selecting_data
  */
-object SelectingDataSection extends FlatSpec with Matchers with Section {
+object SelectingDataSection extends AnyFlatSpec with Matchers with Section {
 
   /**
    * == Getting info about the countries ==

--- a/src/main/scala/doobie/UpdatesSection.scala
+++ b/src/main/scala/doobie/UpdatesSection.scala
@@ -13,7 +13,8 @@ import doobie._
 import doobie.implicits._
 import UpdatesSectionHelpers.Person
 import org.scalaexercises.definitions.Section
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * In this section we examine operations that modify data in the database, and ways to retrieve the
@@ -61,7 +62,7 @@ import org.scalatest.{FlatSpec, Matchers}
  *
  * @param name inserting_and_updating
  */
-object UpdatesSection extends FlatSpec with Matchers with Section {
+object UpdatesSection extends AnyFlatSpec with Matchers with Section {
 
   /**
    * Let's insert a new row by using the recently defined `insert1` method.


### PR DESCRIPTION
This PR updates ScalaTest dependency to version 3.1.0.